### PR TITLE
Support passing key with no files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ signer = AwsCfSigner.new('/path/to/my/pk-1234567890.pem')
 # If the key filename doesn't contain the key_pair_id (as it usually does from AWS), pass that in as the second arg
 signer = AwsCfSigner.new('/path/to/my/private-key.pem', '1234567890')
 
+# If your private key is not on the filesystem, you can pass it explicitly, you need to pass key_pair_id if you do that
+signer = AwsCfSigner.new(ENV["CLOUDFLARE_PRIVATE_KEY"], '1234567890')
+
 # expiration date is required
 # See Example Canned Policy at above AWS doc link
 url = signer.sign('http://d604721fxaaqy9.cloudfront.net/horizon.jpg?large=yes&license=yes', :ending => 'Sat, 14 Nov 2009 22:20:00 GMT')

--- a/lib/aws_cf_signer.rb
+++ b/lib/aws_cf_signer.rb
@@ -6,12 +6,17 @@ class AwsCfSigner
 
   attr_reader :key_pair_id
 
-  def initialize(pem_path, key_pair_id = nil)
-    @pem_path    = pem_path
-    @key         = OpenSSL::PKey::RSA.new(File.readlines(@pem_path).join(""))
-    @key_pair_id = key_pair_id ? key_pair_id : extract_key_pair_id(@pem_path)
-    unless @key_pair_id
-      raise ArgumentError.new("key_pair_id couldn't be inferred from #{@pem_path} - please pass in explicitly")
+  def initialize(key_or_pem_path, key_pair_id = nil)
+    if key_or_pem_path =~ /BEGIN RSA PRIVATE KEY/
+      @key = OpenSSL::PKey::RSA.new(key_or_pem_path)
+      @key_pair_id = key_pair_id or raise ArgumentError, "key_pair_id could not be inferred - please pass in explicitly"
+    else
+      @pem_path    = key_or_pem_path
+      @key         = OpenSSL::PKey::RSA.new(File.readlines(@pem_path).join(""))
+      @key_pair_id = key_pair_id ? key_pair_id : extract_key_pair_id(@pem_path)
+      unless @key_pair_id
+        raise ArgumentError.new("key_pair_id couldn't be inferred from #{@pem_path} - please pass in explicitly")
+      end
     end
   end
 

--- a/test/test_aws_cf_signer.rb
+++ b/test/test_aws_cf_signer.rb
@@ -4,10 +4,20 @@ require 'helper'
 class TestAwsCfSigner < Test::Unit::TestCase
   context "CloudFront Signing" do
     setup do
+      @key = File.read(File.join(File.dirname(__FILE__), 'fixtures', 'pk-PK123456789754.pem'))
       @cf_signer = AwsCfSigner.new(File.join(File.dirname(__FILE__), 'fixtures', 'pk-PK123456789754.pem'))
     end
 
     context "Initialization and Error Checking" do
+      should "be able to extract the key from a file" do
+        assert_equal @cf_signer.instance_variable_get(:@key).to_s, OpenSSL::PKey::RSA.new(@key).to_s
+      end
+
+      should "be able to tell you the explicit private key" do
+        signer = AwsCfSigner.new(@key, 'PK123456789754')
+        assert_equal signer.instance_variable_get(:@key).to_s, OpenSSL::PKey::RSA.new(@key).to_s
+      end
+
       should "be able to extract the key pair id from the filename of a key straight from AWS" do
         assert_equal @cf_signer.extract_key_pair_id('/path/to/my/key/pk-THEKEYID.pem'), 'THEKEYID'
       end


### PR DESCRIPTION
This helps to use the gem in environments where the file-system is not very
usable (e.g. heroku), or where a different solution is used for storing
secrets.
